### PR TITLE
Various junit fixes

### DIFF
--- a/asn1/api/pom.xml
+++ b/asn1/api/pom.xml
@@ -39,12 +39,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>test</scope>

--- a/asn1/ber/pom.xml
+++ b/asn1/ber/pom.xml
@@ -39,12 +39,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-i18n</artifactId>
     </dependency> 

--- a/integ/pom.xml
+++ b/integ/pom.xml
@@ -55,12 +55,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-ldap-schema-data</artifactId>
       <scope>test</scope>

--- a/ldap/client/api/pom.xml
+++ b/ldap/client/api/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
+      <version>2.28.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/LdapNetworkConnectionTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/LdapNetworkConnectionTest.java
@@ -20,7 +20,7 @@
 package org.apache.directory.ldap.client.api;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/LdifAnonymizerTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/LdifAnonymizerTest.java
@@ -21,6 +21,10 @@
 package org.apache.directory.ldap.client.api;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -37,12 +41,8 @@ import org.apache.directory.api.ldap.model.ldif.LdifReader;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.api.ldap.schema.manager.impl.DefaultSchemaManager;
 import org.apache.directory.api.util.Strings;
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -57,7 +57,7 @@ public class LdifAnonymizerTest
     private LdifReader ldifReader;
 
     
-    @Before
+    @BeforeEach
     public void setup()
     {
         schemaManager = null;

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/QuirkySchemaTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/QuirkySchemaTest.java
@@ -20,10 +20,10 @@
 package org.apache.directory.ldap.client.api;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -70,7 +70,7 @@ import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.api.ldap.model.schema.registries.Schema;
 import org.apache.directory.api.ldap.schema.manager.impl.DefaultSchemaManager;
 import org.apache.directory.api.util.exception.Exceptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -140,7 +140,7 @@ public class QuirkySchemaTest
             fail( "Schema load failed : " + Exceptions.printErrors( schemaManager.getErrors() ) );
         }
         
-        assertTrue ( "Surprisingly no errors after load", schemaManager.getErrors().size() > 0 );
+        assertTrue ( schemaManager.getErrors().size() > 0, "Surprisingly no errors after load" );
 
         assertTrue( schemaManager.getRegistries().getAttributeTypeRegistry().contains( "cn" ) );
         ObjectClass person = schemaManager.getRegistries().getObjectClassRegistry().lookup( "person" );

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/ValidatingPoolableLdapConnectionFactoryTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/ValidatingPoolableLdapConnectionFactoryTest.java
@@ -20,8 +20,8 @@
 package org.apache.directory.ldap.client.api;
 
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -38,7 +38,7 @@ import org.apache.directory.api.ldap.model.message.BindResponse;
 import org.apache.directory.api.ldap.model.message.ExtendedRequest;
 import org.apache.directory.api.ldap.model.message.ExtendedResponse;
 import org.apache.directory.api.ldap.model.name.Dn;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.verification.VerificationMode;
@@ -48,8 +48,6 @@ public class ValidatingPoolableLdapConnectionFactoryTest
 {
     private static final String ADMIN_CREDENTIALS = "secret";
     private static final String ADMIN_DN = "uid=admin, ou=system";
-    private static final MockUtil MOCK_UTIL = new MockUtil();
-
 
     @Test
     public void testPoolWithBind()
@@ -266,7 +264,7 @@ public class ValidatingPoolableLdapConnectionFactoryTest
 
     private static final LdapConnection verify( LdapConnection connection, VerificationMode mode )
     {
-        if ( MOCK_UTIL.isMock( connection ) )
+        if ( MockUtil.isMock( connection ) )
         {
             return org.mockito.Mockito.verify( connection, mode );
         }

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/AttributeDescriptionFilterTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/AttributeDescriptionFilterTest.java
@@ -20,11 +20,9 @@
 
 package org.apache.directory.ldap.client.api.search;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/AttributeValueAssertionTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/AttributeValueAssertionTest.java
@@ -19,11 +19,9 @@
  */
 package org.apache.directory.ldap.client.api.search;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/FilterBuilderTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/FilterBuilderTest.java
@@ -29,10 +29,10 @@ import static org.apache.directory.ldap.client.api.search.FilterBuilder.not;
 import static org.apache.directory.ldap.client.api.search.FilterBuilder.or;
 import static org.apache.directory.ldap.client.api.search.FilterBuilder.startsWith;
 import static org.apache.directory.ldap.client.api.search.FilterBuilder.substring;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/MatchingRuleAssertionFilterTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/MatchingRuleAssertionFilterTest.java
@@ -21,10 +21,10 @@
 package org.apache.directory.ldap.client.api.search;
 
 
-import static org.junit.Assert.assertEquals;
 import static org.apache.directory.ldap.client.api.search.FilterBuilder.extensible;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/SetOfFiltersFilterTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/SetOfFiltersFilterTest.java
@@ -20,11 +20,11 @@
 package org.apache.directory.ldap.client.api.search;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/UnaryFilterTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/search/UnaryFilterTest.java
@@ -19,11 +19,9 @@
  */
 package org.apache.directory.ldap.client.api.search;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 /**
  * 

--- a/ldap/codec/core/pom.xml
+++ b/ldap/codec/core/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-util</artifactId>
     </dependency> 

--- a/ldap/codec/core/src/test/java/org/apache/directory/api/ldap/codec/bind/BindRequestTest.java
+++ b/ldap/codec/core/src/test/java/org/apache/directory/api/ldap/codec/bind/BindRequestTest.java
@@ -20,12 +20,12 @@
 package org.apache.directory.api.ldap.codec.bind;
 
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;

--- a/ldap/codec/standalone/pom.xml
+++ b/ldap/codec/standalone/pom.xml
@@ -49,12 +49,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-ldap-net-mina</artifactId>
     </dependency>

--- a/ldap/extras/aci/pom.xml
+++ b/ldap/extras/aci/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-util</artifactId>
     </dependency> 

--- a/ldap/extras/codec-api/pom.xml
+++ b/ldap/extras/codec-api/pom.xml
@@ -41,12 +41,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-ldap-model</artifactId>
     </dependency>

--- a/ldap/extras/codec/pom.xml
+++ b/ldap/extras/codec/pom.xml
@@ -44,12 +44,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-ldap-codec-core</artifactId>
     </dependency>

--- a/ldap/extras/sp/pom.xml
+++ b/ldap/extras/sp/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-util</artifactId>
     </dependency> 

--- a/ldap/extras/trigger/pom.xml
+++ b/ldap/extras/trigger/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-util</artifactId>
     </dependency> 

--- a/ldap/extras/util/pom.xml
+++ b/ldap/extras/util/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-i18n</artifactId>
     </dependency>

--- a/ldap/model/pom.xml
+++ b/ldap/model/pom.xml
@@ -38,11 +38,11 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-util</artifactId>

--- a/ldap/model/src/test/java/org/apache/directory/api/ldap/model/ldif/LdifReaderTest.java
+++ b/ldap/model/src/test/java/org/apache/directory/api/ldap/model/ldif/LdifReaderTest.java
@@ -20,12 +20,12 @@
 package org.apache.directory.api.ldap.model.ldif;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.DataOutputStream;
@@ -1256,8 +1256,8 @@ public class LdifReaderTest
         }
         catch ( Exception ne )
         {
-            assertTrue( I18n.err( I18n.ERR_13442_ERROR_PARSING_LDIF_BUFFER ), 
-                ne.getMessage().startsWith( I18n.ERR_13442_ERROR_PARSING_LDIF_BUFFER.getErrorCode() ) );
+            assertTrue( ne.getMessage().startsWith( I18n.ERR_13442_ERROR_PARSING_LDIF_BUFFER.getErrorCode() ),
+                        I18n.err( I18n.ERR_13442_ERROR_PARSING_LDIF_BUFFER ) );
         }
     }
 

--- a/ldap/model/src/test/java/org/apache/directory/api/ldap/model/schema/syntaxes/parser/SyntaxCheckerDescriptionSchemaParserTest.java
+++ b/ldap/model/src/test/java/org/apache/directory/api/ldap/model/schema/syntaxes/parser/SyntaxCheckerDescriptionSchemaParserTest.java
@@ -28,9 +28,9 @@ import java.text.ParseException;
 
 import org.apache.directory.api.ldap.model.schema.parsers.SyntaxCheckerDescription;
 import org.apache.directory.api.ldap.model.schema.parsers.SyntaxCheckerDescriptionSchemaParser;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 

--- a/ldap/schema/converter/pom.xml
+++ b/ldap/schema/converter/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/ldap/schema/data/pom.xml
+++ b/ldap/schema/data/pom.xml
@@ -42,12 +42,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-i18n</artifactId>
     </dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -45,12 +45,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api-i18n</artifactId>
     </dependency> 

--- a/util/src/test/java/org/apache/directory/api/util/ByteBufferTest.java
+++ b/util/src/test/java/org/apache/directory/api/util/ByteBufferTest.java
@@ -20,7 +20,7 @@
 package org.apache.directory.api.util;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;

--- a/util/src/test/java/org/apache/directory/api/util/GeneralizedTimeTest.java
+++ b/util/src/test/java/org/apache/directory/api/util/GeneralizedTimeTest.java
@@ -20,13 +20,13 @@
 package org.apache.directory.api.util;
 
 import static org.apache.directory.api.util.TimeZones.GMT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -1199,7 +1199,7 @@ public class GeneralizedTimeTest
         Calendar calendar = new GregorianCalendar( GMT, Locale.ROOT );
         calendar.setTime( date );
         GeneralizedTime gt = new GeneralizedTime( calendar );
-        assertEquals( "calendar time must equal the date time", date.getTime(), calendar.getTime().getTime() );
+        assertEquals( date.getTime(), calendar.getTime().getTime(), "calendar time must equal the date time" );
         String gtStr = gt.toGeneralizedTime();
         LOG.info( "generalized time string of original time = {}", gtStr );
 
@@ -1209,8 +1209,7 @@ public class GeneralizedTimeTest
         LOG.info( "recalculated time = {}", recalculatedTime );
         LOG.info( "generalized time string of recalculated time = {}", recalculatedGt.toGeneralizedTime() );
 
-        assertEquals( "The time after round trip GeneralizedTime generation should stay the same",
-            originalTime, recalculatedTime );
+        assertEquals( originalTime, recalculatedTime, "The time after round trip GeneralizedTime generation should stay the same" );
     }
 
     static DateFormat format = new SimpleDateFormat( "dd/MM/yyyy HH:mm:ss.SSSS z", Locale.ROOT );

--- a/util/src/test/java/org/apache/directory/api/util/HexTest.java
+++ b/util/src/test/java/org/apache/directory/api/util/HexTest.java
@@ -24,11 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import javax.naming.NamingException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 
 /**
  * Tests the StringTools class methods.

--- a/util/src/test/java/org/apache/directory/api/util/MethodUtilsTest.java
+++ b/util/src/test/java/org/apache/directory/api/util/MethodUtilsTest.java
@@ -21,9 +21,9 @@
 package org.apache.directory.api.util;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/util/src/test/java/org/apache/directory/api/util/OsgiUtilsTest.java
+++ b/util/src/test/java/org/apache/directory/api/util/OsgiUtilsTest.java
@@ -20,15 +20,14 @@
 package org.apache.directory.api.util;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.util.Set;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for OsgiUtils.
@@ -78,10 +77,10 @@ public class OsgiUtilsTest
             "org.ops4j.store.intern;uses:=\"org.ops4j.store,org.ops4j.io,org.apache.commons.logging\";"
                 + "version=\"1.2.2\",org.ops4j.store;uses:=\"org.ops4j.store.intern\";version=\"1.2.2", null );
 
-        assertTrue( "org.ops4j.store.intern", pkgs.contains( "org.ops4j.store.intern" ) );
-        assertTrue( "org.ops4j.store", pkgs.contains( "org.ops4j.store" ) );
+        assertTrue( pkgs.contains( "org.ops4j.store.intern" ), "org.ops4j.store.intern" );
+        assertTrue( pkgs.contains( "org.ops4j.store" ), "org.ops4j.store" );
 
-        assertEquals( "Expecting 2 packages", 2, pkgs.size() );
+        assertEquals( 2, pkgs.size(), "Expecting 2 packages" );
     }
 
 
@@ -113,22 +112,22 @@ public class OsgiUtilsTest
                 + "org.apache.log4j.spi,org.apache.log4j.or\",org.apache.log4j.varia;uses:=\""
                 + "org.apache.log4j.spi,org.apache.log4j,org.apache.log4j.helpers\"", null );
 
-        assertTrue( "org.apache.log4j.net", pkgs.contains( "org.apache.log4j.net" ) );
-        assertTrue( "org.apache.log4j.jmx", pkgs.contains( "org.apache.log4j.jmx" ) );
-        assertTrue( "org.apache.log4j.jdbc", pkgs.contains( "org.apache.log4j.jdbc" ) );
-        assertTrue( "org.apache.log4j.config", pkgs.contains( "org.apache.log4j.config" ) );
-        assertTrue( "org.apache.log4j.helpers", pkgs.contains( "org.apache.log4j.helpers" ) );
-        assertTrue( "org.apache.log4j", pkgs.contains( "org.apache.log4j" ) );
-        assertTrue( "org.apache.log4j.or", pkgs.contains( "org.apache.log4j.or" ) );
-        assertTrue( "org.apache.log4j.or.jms", pkgs.contains( "org.apache.log4j.or.jms" ) );
-        assertTrue( "org.apache.log4j.or.sax", pkgs.contains( "org.apache.log4j.or.sax" ) );
-        assertTrue( "org.apache.log4j.nt", pkgs.contains( "org.apache.log4j.nt" ) );
-        assertTrue( "org.apache.log4j.spi", pkgs.contains( "org.apache.log4j.spi" ) );
-        assertTrue( "org.apache.log4j.pattern", pkgs.contains( "org.apache.log4j.pattern" ) );
-        assertTrue( "org.apache.log4j.xml", pkgs.contains( "org.apache.log4j.xml" ) );
-        assertTrue( "org.apache.log4j.varia", pkgs.contains( "org.apache.log4j.varia" ) );
+        assertTrue( pkgs.contains( "org.apache.log4j.net" ), "org.apache.log4j.net" );
+        assertTrue( pkgs.contains( "org.apache.log4j.jmx" ), "org.apache.log4j.jmx" );
+        assertTrue( pkgs.contains( "org.apache.log4j.jdbc" ), "org.apache.log4j.jdbc" );
+        assertTrue( pkgs.contains( "org.apache.log4j.config" ), "org.apache.log4j.config" );
+        assertTrue( pkgs.contains( "org.apache.log4j.helpers" ), "org.apache.log4j.helpers" );
+        assertTrue( pkgs.contains( "org.apache.log4j" ), "org.apache.log4j" );
+        assertTrue( pkgs.contains( "org.apache.log4j.or" ), "org.apache.log4j.or" );
+        assertTrue( pkgs.contains( "org.apache.log4j.or.jms" ), "org.apache.log4j.or.jms" );
+        assertTrue( pkgs.contains( "org.apache.log4j.or.sax" ), "org.apache.log4j.or.sax" );
+        assertTrue( pkgs.contains( "org.apache.log4j.nt" ), "org.apache.log4j.nt" );
+        assertTrue( pkgs.contains( "org.apache.log4j.spi" ), "org.apache.log4j.spi" );
+        assertTrue( pkgs.contains( "org.apache.log4j.pattern" ), "org.apache.log4j.pattern" );
+        assertTrue( pkgs.contains( "org.apache.log4j.xml" ), "org.apache.log4j.xml" );
+        assertTrue( pkgs.contains( "org.apache.log4j.varia" ), "org.apache.log4j.varia" );
 
-        assertEquals( "Expecting 14 packages", 14, pkgs.size() );
+        assertEquals( 14, pkgs.size(), "Expecting 14 packages" );
     }
 
 
@@ -136,16 +135,16 @@ public class OsgiUtilsTest
     public void testGetClasspathCandidates()
     {
         Set<File> candidates = OsgiUtils.getClasspathCandidates( REJECTION_FILTER );
-        assertEquals( "Should have no results with REJECTION_FILTER", 0, candidates.size() );
+        assertEquals(  0, candidates.size(), "Should have no results with REJECTION_FILTER" );
 
         candidates = OsgiUtils.getClasspathCandidates( ONLY_ONE_FILTER );
-        assertEquals( "Should have one result with ONLY_ONE_FILTER", 1, candidates.size() );
+        assertEquals( 1, candidates.size(), "Should have one result with ONLY_ONE_FILTER" );
 
         candidates = OsgiUtils.getClasspathCandidates( JUNIT_SLF4J_FILTER );
-        assertTrue( "Should have at least 4 results with JUNIT_SLF4J_FILTER", candidates.size() >= 4 );
+        assertTrue( candidates.size() >= 4, "Should have at least 4 results with JUNIT_SLF4J_FILTER" );
 
         candidates = OsgiUtils.getClasspathCandidates( null );
-        assertTrue( "Should have at least 4 results with no filter", candidates.size() >= 4 );
+        assertTrue( candidates.size() >= 4, "Should have at least 4 results with no filter" );
     }
 
 


### PR DESCRIPTION
These fixes include:
a) Converting some remaining Junit4 tests to Junit5 so they actually run
b) Removing various old org.junit.assert* stuff in junit5 tests
c) Remove junit4 platform runner from modules that don't need it
d) Upgrade Mockito to version 2.x