### PR TITLE
LdapConnectionConfig: Removed outdated comment

### DIFF
--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapConnectionConfig.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapConnectionConfig.java
@@ -139,8 +139,6 @@ public class LdapConnectionConfig
 
     /**
      * Sets the default trust manager based on the SunX509 trustManagement algorithm
-     * 
-     * We use a non-verification Trust Manager    
      **/
     private void setDefaultTrustManager()
     {


### PR DESCRIPTION
The default Trust manager was changed in the past from
no Verification to default trust.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>