### PR TITLE
Update mina.core version to avoid CVE-2021-41973

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <junit.platform.version>1.7.2</junit.platform.version>
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.3.0-alpha5</logback.version>
-    <mina.core.version>2.1.3</mina.core.version>
+    <mina.core.version>2.1.5</mina.core.version>
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.apache.felix.version>7.0.1</org.apache.felix.version>
     <pax-exam.version>4.13.4</pax-exam.version>


### PR DESCRIPTION
This was a nasty CVE and it's been fixed in mina-core 2.1.5: https://www.openwall.com/lists/oss-security/2021/11/01/2