### PR TITLE
Fixed DSML serialization of binary LDAP attributes.

### DIFF
--- a/dsml/parser/src/main/java/org/apache/directory/api/dsmlv2/response/SearchResultEntryDsml.java
+++ b/dsml/parser/src/main/java/org/apache/directory/api/dsmlv2/response/SearchResultEntryDsml.java
@@ -171,7 +171,7 @@ public class SearchResultEntryDsml
                     }
 
                     Element valueElement = attributeElement.addElement( "value" ).addText(
-                        ParserUtils.base64Encode( value.getString() ) );
+                        ParserUtils.base64Encode( value.getBytes() ) );
                     valueElement.addAttribute( new QName( "type", xsiNamespace ), ParserUtils.XSD + ":"
                         + ParserUtils.BASE64BINARY );
                 }


### PR DESCRIPTION
We never want to base64-encode String representation of non-readable attributes.  
Without this change (almost) any non-readable binary attribute value is broken in DSML representation.