### PR TITLE
DIRAPI-398 / java.lang.IllegalStateException: Returned object not currently part of this pool

### DIFF
--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/AbstractPoolableLdapConnectionFactory.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/AbstractPoolableLdapConnectionFactory.java
@@ -54,37 +54,24 @@ public abstract class AbstractPoolableLdapConnectionFactory implements PooledObj
     {
         private final LdapConnectionFactory delegate;
 
-        private final LdapConnectionPool connectionPool;
 
-        PooledLdapConnectionFactory( LdapConnectionFactory delegate, LdapConnectionPool connectionPool )
+        PooledLdapConnectionFactory( LdapConnectionFactory delegate )
         {
             this.delegate = delegate;
-            this.connectionPool = connectionPool;
-        }
-
-
-        private LdapConnection wrap( LdapConnection ldapConnection )
-        {
-            if ( ldapConnection instanceof PooledLdapConnection )
-            {
-                return ldapConnection;
-            }
-
-            return new PooledLdapConnection( ldapConnection, connectionPool );
         }
 
 
         @Override
         public LdapConnection bindConnection( LdapConnection connection ) throws LdapException
         {
-            return wrap( delegate.bindConnection( connection ) );
+            return delegate.bindConnection( connection );
         }
 
 
         @Override
         public LdapConnection configureConnection( LdapConnection connection )
         {
-            return wrap( delegate.configureConnection( connection ) );
+            return delegate.configureConnection( connection );
         }
 
 
@@ -98,14 +85,14 @@ public abstract class AbstractPoolableLdapConnectionFactory implements PooledObj
         @Override
         public LdapConnection newLdapConnection() throws LdapException
         {
-            return wrap( delegate.newLdapConnection() );
+            return delegate.newLdapConnection();
         }
 
 
         @Override
         public LdapConnection newUnboundLdapConnection()
         {
-            return wrap( delegate.newUnboundLdapConnection() );
+            return delegate.newUnboundLdapConnection();
         }
     }
     
@@ -120,11 +107,6 @@ public abstract class AbstractPoolableLdapConnectionFactory implements PooledObj
         this.connectionFactory = connectionFactory;
     }
 
-    
-    void configurePooledLdapConnectionFactory( LdapConnectionPool connectionPool )
-    {
-        this.connectionFactory = new PooledLdapConnectionFactory( connectionFactory, connectionPool );
-    }
     
     
     /**

--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapConnectionPool.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapConnectionPool.java
@@ -166,6 +166,11 @@ public class LdapConnectionPool extends GenericObjectPool<LdapConnection>
      */
     public void releaseConnection( LdapConnection connection ) throws LdapException
     {
+        // Unwrap if required
+        if(connection instanceof PooledLdapConnection) {
+           releaseConnection(((PooledLdapConnection) connection).wrapped());
+           return;
+        }
         try
         {
             super.returnObject( connection );

--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapConnectionPool.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapConnectionPool.java
@@ -96,11 +96,6 @@ public class LdapConnectionPool extends GenericObjectPool<LdapConnection>
     {
         super( factory, poolConfig == null ? new GenericObjectPoolConfig() : poolConfig );
         this.factory = factory;
-        
-        if ( factory instanceof AbstractPoolableLdapConnectionFactory )
-        {
-            ( ( AbstractPoolableLdapConnectionFactory ) factory ).configurePooledLdapConnectionFactory( this );
-        }
     }
 
 
@@ -147,7 +142,7 @@ public class LdapConnectionPool extends GenericObjectPool<LdapConnection>
             throw new RuntimeException( e );
         }
 
-        return connection;
+        return new PooledLdapConnection(connection, this);
     }
 
 

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/PooledLdapConnectionTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/PooledLdapConnectionTest.java
@@ -20,16 +20,34 @@
 
 package org.apache.directory.ldap.client.api;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
 import java.io.IOException;
+
+import org.apache.commons.pool2.PooledObject;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.*;
 
 public class PooledLdapConnectionTest
 {
+
+    private static class PooledObjectAnswer implements Answer<PooledObject<LdapConnection>> {
+
+        private PooledObject<LdapConnection> result;
+
+        public PooledObject<LdapConnection> getResult() {
+            return result;
+        }
+        @Override
+        public PooledObject<LdapConnection> answer(InvocationOnMock invocationOnMock) throws Throwable {
+            result = (PooledObject) invocationOnMock.callRealMethod();
+            return result;
+        }
+    }
     @Test
     void closeReleasesToPool() throws IOException, LdapException
     {
@@ -46,4 +64,68 @@ public class PooledLdapConnectionTest
         verify( spyPooledConnection ).close(); // auto-closed
         verify( pool ).releaseConnection( connection ); // close called releaseConnection
     }
+
+    @Test
+    void closeReleasesToPoolValidatingFactory() throws IOException, LdapException
+    {
+        LdapConnection connection = mock( LdapConnection.class );
+        final LdapConnectionConfig config = new LdapConnectionConfig();
+        final DefaultLdapConnectionFactory connectionFactory = spy(new DefaultLdapConnectionFactory(config));
+        doReturn(connection).when(connectionFactory).newLdapConnection();
+        doReturn(connection).when(connectionFactory).newUnboundLdapConnection();
+        final ValidatingPoolableLdapConnectionFactory validatingFactory = spy(new ValidatingPoolableLdapConnectionFactory(connectionFactory));
+        // We need to capture the result of the makeObject call in the validating connection factory,
+        // because the validating connection factory wraps the network connection with a different object
+        // (MonitoringLdapConnection).
+        final PooledObjectAnswer answer = new PooledObjectAnswer();
+        doAnswer(answer).when(validatingFactory).makeObject();
+        LdapConnectionPool pool = spy(new LdapConnectionPool( validatingFactory ));
+        final PooledLdapConnection spyPooledConnection = spy((PooledLdapConnection) pool.getConnection());
+        try(PooledLdapConnection pooledConnection = spyPooledConnection)
+        {
+            pooledConnection.isConnected();
+        }
+        verify( spyPooledConnection ).isConnected(); // called inside the try-with-resources block
+        verify(spyPooledConnection).close(); // auto close
+        verify( pool ).releaseConnection( answer.getResult().getObject() ); // close called releaseConnection with the monitored connection
+    }
+
+    @Test
+    void closeReleasesToPoolNonValidatingFactory() throws IOException, LdapException
+    {
+        LdapConnection connection = mock( LdapConnection.class );
+        final LdapConnectionConfig config = new LdapConnectionConfig();
+        final DefaultLdapConnectionFactory connectionFactory = spy(new DefaultLdapConnectionFactory(config));
+        doReturn(connection).when(connectionFactory).newLdapConnection();
+        doReturn(connection).when(connectionFactory).newUnboundLdapConnection();
+        LdapConnectionPool pool = spy(new LdapConnectionPool( new DefaultPoolableLdapConnectionFactory(connectionFactory) ));
+        final PooledLdapConnection spyPooledConnection = spy((PooledLdapConnection) pool.getConnection());
+        try(PooledLdapConnection pooledConnection = spyPooledConnection)
+        {
+            pooledConnection.isConnected();
+        }
+        verify( spyPooledConnection ).isConnected(); // called inside the try-with-resources block
+        verify(spyPooledConnection).close(); // auto close
+        verify( pool ).releaseConnection( connection ); // close called releaseConnection
+    }
+
+
+    // use manually by adding @Test, simply adjust ldap server host and port
+    void e2e() throws IOException, LdapException
+    {
+        final String testLdapHOst = "ldap-testing-host";
+        final LdapConnectionConfig config = new LdapConnectionConfig();
+        config.setLdapPort(389);
+        config.setLdapHost(testLdapHOst);
+        LdapConnectionPool pool = spy(new LdapConnectionPool(new ValidatingPoolableLdapConnectionFactory(config)));
+        try  {
+            final LdapConnection connection = pool.getConnection();
+            Assertions.assertTrue(connection.isConnected());
+            Assertions.assertDoesNotThrow(() -> connection.close());
+        } catch(final Exception e) {
+            Assertions.fail(e);
+        }
+        verify(pool, times(1)).releaseConnection(any(LdapConnection.class));
+    }
+
 }

--- a/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/ValidatingPoolableLdapConnectionFactoryTest.java
+++ b/ldap/client/api/src/test/java/org/apache/directory/ldap/client/api/ValidatingPoolableLdapConnectionFactoryTest.java
@@ -518,7 +518,7 @@ public class ValidatingPoolableLdapConnectionFactoryTest
                 assertNotNull( connection );
                 internal = ( InternalMonitoringLdapConnection ) unwrap( unwrap( connection ) ); // two levels of wrapping
                 borrowedCount = internal.incrementBorrowedCount();
-                org.mockito.Mockito.verify( validator, times( 2 * borrowedCount - 1 ) ).validate( connection );
+                org.mockito.Mockito.verify( validator, times( 2 * borrowedCount - 1 ) ).validate( unwrap( connection ) );
                 internal.resetMonitors();
 
                 withConnection.execute( connection, internal.counts );
@@ -533,7 +533,7 @@ public class ValidatingPoolableLdapConnectionFactoryTest
                 {
                     int adminBindCount = internal.counts.adminBindCount;
                     pool.releaseConnection( connection );
-                    org.mockito.Mockito.verify( validator, times( 2 * borrowedCount ) ).validate( connection );
+                    org.mockito.Mockito.verify( validator, times( 2 * borrowedCount ) ).validate( unwrap(connection) );
 
                     if ( internal.startTlsCalled() )
                     {


### PR DESCRIPTION
Wrapped the underlying connection only when the pool.getConnection() method is called. Added test for validating and non-validating connection factory. Remove pool ref from connection factory.