### PR TITLE
 Fix incorrect ResourceBundle reference in message logging function

### DIFF
--- a/i18n/src/main/java/org/apache/directory/api/i18n/I18n.java
+++ b/i18n/src/main/java/org/apache/directory/api/i18n/I18n.java
@@ -1609,7 +1609,7 @@ public enum I18n
         sb.append( msg ).append( ' ' );
         try
         {
-            return sb.append( format( ERR_BUNDLE.getString( msg.getErrorCode() ), args ) ).toString();
+            return sb.append( format( MSG_BUNDLE.getString( msg.getErrorCode() ), args ) ).toString();
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
**Title:** Fix incorrect ResourceBundle reference in message logging function

**Description:**

While integrating this module into my local project, I encountered the following error:

```
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key MSG_04100_BIND_FAIL
```

Upon investigation, it appears that the function intended to use `MSG_BUNDLE` is incorrectly referencing `ERR_BUNDLE`. After updating the code to use the correct bundle (`MSG_BUNDLE`), the issue was resolved and logging now works as expected.

I’ve included the fix in this PR.

If the original use of `ERR_BUNDLE` is intentional, could someone clarify its intended use case—especially if it's used internally, such as in LDAP-related logic? I'm happy to adjust the fix accordingly if there's a broader context I'm missing.

---
Error Logs from Service
---
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key MSG_04100_BIND_FAIL
	at java.base/java.util.ResourceBundle.getObject(ResourceBundle.java:567)
	at java.base/java.util.ResourceBundle.getString(ResourceBundle.java:523)
..........................
..........................
at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:635)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)