### PR TITLE
Remove serialization code from SequencedHashMap

### DIFF
--- a/util/src/main/java/org/apache/directory/api/util/SequencedHashMap.java
+++ b/util/src/main/java/org/apache/directory/api/util/SequencedHashMap.java
@@ -19,11 +19,6 @@
  */
 package org.apache.directory.api.util;
 
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
 import java.util.ArrayList;
@@ -58,11 +53,8 @@ import org.apache.directory.api.i18n.I18n;
  * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
  */
 @SuppressWarnings("rawtypes")
-public class SequencedHashMap implements Map, Cloneable, Externalizable
+public class SequencedHashMap implements Map
 {
-    /** Declares the Serial Version Uid */
-    private static final long serialVersionUID = 3380552487888102930L;
-    
     // constants to define what the iterator should return on "next"
     /** The iterator will return the key */
     private static final int KEY = 0;
@@ -1336,48 +1328,4 @@ public class SequencedHashMap implements Map, Cloneable, Externalizable
         return remove( get( index ) );
     }
 
-
-    // per Externalizable.readExternal(ObjectInput)
-
-    /**
-     * Deserializes this map from the given stream.
-     * 
-     * @param in
-     *            the stream to deserialize from
-     * @throws IOException
-     *             if the stream raises it
-     * @throws ClassNotFoundException
-     *             if the stream raises it
-     */
-    @Override
-    public void readExternal( ObjectInput in ) throws IOException, ClassNotFoundException
-    {
-        int size = in.readInt();
-        for ( int i = 0; i < size; i++ )
-        {
-            Object key = in.readObject();
-            Object value = in.readObject();
-            put( key, value );
-        }
-    }
-
-
-    /**
-     * Serializes this map to the given stream.
-     * 
-     * @param out
-     *            the stream to serialize to
-     * @throws IOException
-     *             if the stream raises it
-     */
-    @Override
-    public void writeExternal( ObjectOutput out ) throws IOException
-    {
-        out.writeInt( size() );
-        for ( MapEntry pos = sentinel.next; pos != sentinel; pos = pos.next )
-        {
-            out.writeObject( pos.getKey() );
-            out.writeObject( pos.getValue() );
-        }
-    }
 }

--- a/util/src/main/java/org/apache/directory/api/util/SynchronizedLRUMap.java
+++ b/util/src/main/java/org/apache/directory/api/util/SynchronizedLRUMap.java
@@ -19,10 +19,6 @@
  */
 package org.apache.directory.api.util;
 
-
-import java.io.Externalizable;
-
-
 /**
  * <p>
  * An implementation of a Map which has a maximum size and uses a Least Recently
@@ -45,10 +41,8 @@ import java.io.Externalizable;
  * @since Commons Collections 1.0
  * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
  */
-public final class SynchronizedLRUMap extends SequencedHashMap implements Externalizable
+public final class SynchronizedLRUMap extends SequencedHashMap
 {
-    /** Declares the Serial Version Uid */
-    private static final long serialVersionUID = 2197433140769957051L;
 
     /** Maximum size */
     private int maximumSize = 0;


### PR DESCRIPTION
The deserialization code in SequencedHashMap is a security risk:
```
SequencedHashMap.readExternal() calls in.readObject() for both keys and values without any type restriction, which is a classic gadget-chain deserialization vector. The other readExternal implementations deserialize known types via internal delegation, but are all exposed to any caller that passes an untrusted ObjectInput.
```
We don't use it in the API or Directory Server so let's just remove it